### PR TITLE
Add ability to identify disconnected devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="jp.co.cyberagent.stf">
+  xmlns:tools="http://schemas.android.com/tools"
+  package="jp.co.cyberagent.stf">
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
@@ -11,6 +12,8 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.DUMP"
+      tools:ignore="ProtectedPermissions" />
 
     <application android:allowBackup="true"
         android:label="@string/app_name"

--- a/app/src/main/java/jp/co/cyberagent/stf/IdentityActivity.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/IdentityActivity.java
@@ -94,6 +94,7 @@ public class IdentityActivity extends Activity {
 
         window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
         window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
+        window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
 
         unlock();
 

--- a/app/src/main/java/jp/co/cyberagent/stf/IdentityActivity.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/IdentityActivity.java
@@ -2,10 +2,13 @@ package jp.co.cyberagent.stf;
 
 import android.app.Activity;
 import android.app.KeyguardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.view.Gravity;
@@ -131,5 +134,26 @@ public class IdentityActivity extends Activity {
     private void unlock() {
         KeyguardManager keyguardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
         keyguardManager.newKeyguardLock("InputService/Unlock").disableKeyguard();
+    }
+
+    public static class IntentBuilder {
+        @Nullable private String serial;
+
+        public IntentBuilder() {
+        }
+
+        public IntentBuilder serial(@NonNull String serial) {
+            this.serial = serial;
+            return this;
+        }
+
+        public Intent build(Context context) {
+            Intent intent = new Intent(context.getApplicationContext(), IdentityActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (serial != null) {
+                intent.putExtra(IdentityActivity.EXTRA_SERIAL, serial);
+            }
+            return intent;
+        }
     }
 }

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -376,21 +376,21 @@ public class Service extends android.app.Service {
 
     /**
      * Monitors the adb state by checking /sys/class/android_usb/android0/state
-     *
+     * <p>
      * If state is DISCONNECTED then IdentityActivity will be shown to allow easier identification
      * of malfunctioning devices
      */
     private class AdbMonitor extends Thread {
         // If something goes wrong you have 30 seconds to kill the STFService
         // Using smaller numbers will basically lock the devices until usb connection is established
-        private static final int INTERVAL_MS = 5000;
+        private static final int INTERVAL_MS = 30000;
 
         @Override
         public void run() {
             Log.d(TAG, "Starting adb monitor thread");
             java.lang.Process process;
             try {
-                while(!isInterrupted()) {
+                while (!isInterrupted()) {
                     /**
                      * In order for the monitor to work you need to grant DUMP permission for
                      * the apk, e.g.
@@ -398,7 +398,7 @@ public class Service extends android.app.Service {
                      * adb -d shell pm grant jp.co.cyberagent.stf android.permission.DUMP
                      */
                     int dumpPermission = ContextCompat.checkSelfPermission(getApplication(), Manifest.permission.DUMP);
-                    if(dumpPermission == PackageManager.PERMISSION_GRANTED) {
+                    if (dumpPermission == PackageManager.PERMISSION_GRANTED) {
                         String[] cmd = {
                             "/system/bin/dumpsys",
                             "usb"

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -389,6 +389,7 @@ public class Service extends android.app.Service {
         public void run() {
             Log.d(TAG, "Starting adb monitor thread");
             java.lang.Process process;
+            String state = "";
             try {
                 while (!isInterrupted()) {
                     /**
@@ -410,17 +411,20 @@ public class Service extends android.app.Service {
                          * If the output of the command will change then by default device will be
                          * considered connected
                          */
-                        String kernelStateLine = "";
+                        String currentState = "";
                         BufferedReader adbdStateReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
                         for (String line = adbdStateReader.readLine(); line != null; line = adbdStateReader.readLine()) {
                             if (line.contains("Kernel state:")) {
-                                kernelStateLine = line;
+                                currentState = line.split(":").length == 2 ? line.split(":")[1] : "";
                                 break;
                             }
                         }
 
-                        Log.d(TAG, kernelStateLine);
-                        boolean disconnected = kernelStateLine.contains("DISCONNECTED");
+                        if (!currentState.equals(state)) {
+                            Log.d(TAG, "Kernel state changed to" + currentState);
+                            state = currentState;
+                        }
+                        boolean disconnected = state.contains("DISCONNECTED");
 
                         if (disconnected) {
                             startActivity(new Intent(getApplication(), IdentityActivity.class));

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -415,7 +415,7 @@ public class Service extends android.app.Service {
                         String currentAdbState = "";
                         BufferedReader adbdStateReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
                         for (String line = adbdStateReader.readLine(); line != null; line = adbdStateReader.readLine()) {
-                            if (line.contains("Current Functions:")) {
+                            if (line.contains("Current Functions:") || line.contains("mCurrentFunctions:")) {
                                 currentAdbState = line.split(":").length == 2 ? line.split(":")[1] : "";
                             } else if (line.contains("Kernel state:")) {
                                 currentUsbState = line.split(":").length == 2 ? line.split(":")[1] : "";

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -388,7 +388,6 @@ public class Service extends android.app.Service {
         @Override
         public void run() {
             Log.d(TAG, "Starting adb monitor thread");
-            java.lang.Process process;
             String state = "";
             try {
                 while (!isInterrupted()) {
@@ -405,7 +404,7 @@ public class Service extends android.app.Service {
                             "usb"
                         };
 
-                        process = Runtime.getRuntime().exec(cmd);
+                        java.lang.Process process = Runtime.getRuntime().exec(cmd);
 
                         /**
                          * If the output of the command will change then by default device will be
@@ -424,13 +423,14 @@ public class Service extends android.app.Service {
                             Log.d(TAG, "Kernel state changed to" + currentState);
                             state = currentState;
                         }
-                        boolean disconnected = state.contains("DISCONNECTED");
 
+                        boolean disconnected = state.contains("DISCONNECTED");
                         if (disconnected) {
                             startActivity(new Intent(getApplication(), IdentityActivity.class));
                         }
 
                         adbdStateReader.close();
+                        process.waitFor();
                     }
 
                     Thread.sleep(INTERVAL_MS);

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -1,19 +1,24 @@
 package jp.co.cyberagent.stf;
 
+import android.Manifest;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.os.IBinder;
 import android.os.Process;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,6 +161,17 @@ public class Service extends android.app.Service {
                     addMonitor(new BrowserPackageMonitor(this, writers));
 
                     executor.submit(new Server(acceptor));
+
+                    /**
+                     * In order for the monitor to work you need to grant DUMP permission for
+                     * the apk, e.g.
+                     *
+                     * adb -d shell pm grant jp.co.cyberagent.stf android.permission.DUMP
+                     */
+                    int dumpPermission = ContextCompat.checkSelfPermission(getApplication(), Manifest.permission.DUMP);
+                    if(dumpPermission == PackageManager.PERMISSION_GRANTED) {
+                        executor.submit(new AdbMonitor());
+                    }
 
                     started = true;
                 }
@@ -364,6 +380,50 @@ public class Service extends android.app.Service {
                     }
                 }
 
+            }
+        }
+    }
+
+    /**
+     * Monitors the adb state by checking /sys/class/android_usb/android0/state
+     *
+     * If state is DISCONNECTED then IdentityActivity will be shown to allow easier identification
+     * of malfunctioning devices
+     */
+    private class AdbMonitor extends Thread {
+        // If something goes wrong you have 30 seconds to kill the STFService
+        // Using smaller numbers will basically lock the devices until usb connection is established
+        private static final int INTERVAL_MS = 30000;
+
+        @Override
+        public void run() {
+            Log.d(TAG, "Starting adb monitor thread");
+            java.lang.Process process;
+            try {
+                while(!isInterrupted()) {
+                    String[] cmd = {
+                        "/system/bin/sh",
+                        "-c",
+                        "dumpsys usb -a | grep \"Kernel state:\""
+                    };
+
+                    process = Runtime.getRuntime().exec(cmd);
+                    BufferedReader adbdStateReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                    String line = adbdStateReader.readLine();
+                    Log.d(TAG, line);
+                    boolean disconnected = line.contains("DISCONNECTED");
+
+                    if (disconnected) {
+                        startActivity(new Intent(getApplication(), IdentityActivity.class));
+                    }
+
+                    adbdStateReader.close();
+                    Thread.sleep(INTERVAL_MS);
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "IO error during exec of adb monitor", e);
+            } catch (InterruptedException e) {
+                Log.i(TAG, "Adb monitor thread interrupted");
             }
         }
     }

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -426,7 +426,7 @@ public class Service extends android.app.Service {
 
                         boolean disconnected = state.contains("DISCONNECTED");
                         if (disconnected) {
-                            startActivity(new Intent(getApplication(), IdentityActivity.class));
+                            getApplication().startActivity(new IdentityActivity.IntentBuilder().build(getApplication()));
                         }
 
                         adbdStateReader.close();

--- a/app/src/main/java/jp/co/cyberagent/stf/query/DoIdentifyResponder.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/query/DoIdentifyResponder.java
@@ -1,7 +1,6 @@
 package jp.co.cyberagent.stf.query;
 
 import android.content.Context;
-import android.content.Intent;
 
 import com.google.protobuf.GeneratedMessageLite;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -37,9 +36,8 @@ public class DoIdentifyResponder extends AbstractResponder {
     }
 
     private void showIdentity(String serial) {
-        Intent intent = new Intent(context, IdentityActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.putExtra(IdentityActivity.EXTRA_SERIAL, serial);
-        context.startActivity(intent);
+        context.startActivity(new IdentityActivity.IntentBuilder()
+            .serial(serial)
+            .build(context));
     }
 }


### PR DESCRIPTION
If android.permission.DUMP is granted to the package (e.g. adb -d shell pm grant jp.co.cyberagent.stf android.permission.DUMP), then STFService will show IdentifyActivity when device is disconnected from the USB. This allows easier maintenance of devices by quickly identifying the faulty ones.

