### PR TITLE
AdbMonitor should skip the check if we're running on an emulator

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -407,7 +407,7 @@ public class Service extends android.app.Service {
                      * adb -d shell pm grant jp.co.cyberagent.stf android.permission.DUMP
                      */
                     int dumpPermission = ContextCompat.checkSelfPermission(getApplication(), Manifest.permission.DUMP);
-                    if (dumpPermission == PackageManager.PERMISSION_GRANTED) {
+                    if (dumpPermission == PackageManager.PERMISSION_GRANTED && !isEmulator()) {
                         String[] cmd = {
                             "/system/bin/dumpsys",
                             "usb"
@@ -457,6 +457,17 @@ public class Service extends android.app.Service {
                 Log.e(TAG, "IO error during exec of adb monitor", e);
             } catch (InterruptedException e) {
                 Log.i(TAG, "Adb monitor thread interrupted");
+            }
+        }
+
+        private boolean isEmulator() {
+            String hardware = System.getProperty("ro.hardware");
+            switch (hardware) {
+                case "goldfish":
+                case "ranchu":
+                    return true;
+                default:
+                    return false;
             }
         }
     }


### PR DESCRIPTION
I've found that emulator doesn't actually have any data we can use in the output of dumpsys usb. I suggest we skip this case in the AdbMonitor.

The other way would be to control this from the permission granting side, but that would complicate deployment so I suggest we just support this in the STFService.apk