### PR TITLE
Show device serial on Oreo devices

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/IdentityActivity.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/IdentityActivity.java
@@ -51,7 +51,11 @@ public class IdentityActivity extends Activity {
         String serial = intent.getStringExtra(EXTRA_SERIAL);
 
         if (serial == null) {
-            serial = getProperty("ro.serialno", "unknown");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                serial = Build.getSerial();
+            } else {
+                serial = getProperty("ro.serialno", "unknown");
+            }
         }
 
         layout.addView(createLabel("SERIAL"));


### PR DESCRIPTION
Fix for #29 

It works on our devices. 