### PR TITLE
Always starting minitouch agent

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/Agent.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Agent.java
@@ -52,17 +52,19 @@ public class Agent extends Thread {
                 System.exit(1);
             }
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            /*
-             * Android Q doesn't let minitouch manage inputs.
-             * As a workaround, minitouch will forward events to this
-             * agent which will be able to use the Android InputManager
-             */
-            System.out.println("Starting minitouch agent");
-            Point size = MinitouchAgent.getScreenSize();
-            MinitouchAgent m = new MinitouchAgent(size.x, size.y, handler);
-            m.start();
-        }
+
+        /*
+         * Android Q doesn't let minitouch manage inputs. Also minitouch cannot handle devices
+         * without a multi touch libevdev input device, such as devices without a multi touch
+         * screen.
+         * As a workaround, minitouch will forward events to this
+         * agent which will be able to use the Android InputManager
+         */
+        System.out.println("Starting minitouch agent");
+        Point size = MinitouchAgent.getScreenSize();
+        MinitouchAgent m = new MinitouchAgent(size.x, size.y, handler);
+        m.start();
+
         new Agent(handler).start();
         Looper.loop();
     }


### PR DESCRIPTION
Hi,

I'd like to suggest that the minitouch agent always be started, not just for Android Q.
That way we can use it when devices don't have a libevdev multi touch input device.
As such https://github.com/openstf/minitouch/pull/15 can be closed, as we now have a better solution.
My personal use case is that I need stf to be able to remotely control my Android devices running without a (working) touch screen. (Using the boards of old phones to turn them into remotely operated vehicles)